### PR TITLE
Remove Netlify Identity

### DIFF
--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -1,8 +1,7 @@
 backend:
-  name: git-gateway
-  accept_roles:
-    - admin
-    - editor
+  name: github
+  repo: devpt-org/devpt-org.github.io
+  branch: master
   site_domain: stupefied-pasteur-4f4a2c.netlify.com
 
 media_folder: "images/uploads"

--- a/static/admin/emails/confirmation.html
+++ b/static/admin/emails/confirmation.html
@@ -1,4 +1,0 @@
-<h2>Confirm your signup</h2>
-
-<p>Follow this link to confirm your user:</p>
-<p><a href="{{ .SiteURL }}/admin/#confirmation_token={{ .Token }}">Confirm your mail</a></p>

--- a/static/admin/emails/email-change.html
+++ b/static/admin/emails/email-change.html
@@ -1,4 +1,0 @@
-<h2>Confirm Change of Email</h2>
-
-<p>Follow this link to confirm the update of your email from {{ .Email }} to {{ .NewEmail }}:</p>
-<p><a href="{{ .SiteURL }}/admin/#email_change_token={{ .Token }}">Change Email</a></p>

--- a/static/admin/emails/invitation.html
+++ b/static/admin/emails/invitation.html
@@ -1,4 +1,0 @@
-<h2>You have been invited</h2>
-
-<p>You have been invited to create a user on {{ .SiteURL }}. Follow this link to accept the invite:</p>
-<p><a href="{{ .SiteURL }}/admin/#invite_token={{ .Token }}">Accept the invite</a></p>

--- a/static/admin/emails/recovery.html
+++ b/static/admin/emails/recovery.html
@@ -1,4 +1,0 @@
-<h2>Reset Password</h2>
-
-<p>Follow this link to reset the password for your user:</p>
-<p><a href="{{ .SiteURL }}/admin/#recovery_token={{ .Token }}">Reset Password</a></p>

--- a/static/admin/index.html
+++ b/static/admin/index.html
@@ -4,8 +4,6 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Content Manager</title>
-    <!-- Include the script that enables Netlify Identity on this page. -->
-    <script src="https://identity.netlify.com/v1/netlify-identity-widget.js"></script>
   </head>
   <body>
     <!-- Include the script that builds the page and powers Netlify CMS -->


### PR DESCRIPTION
[According to a Netlify staff member](https://community.netlify.com/t/unable-to-access-identity-settings-when-using-git-gateway-backend-make-sure-to-enable-identity-service-and-git-gateway-for-github-pages-deployment/19950/2), Netlify Identity does not seem to work with Github Hosted Pages, so access to creation and edition of content will be limited for users with push access to the repository.