### PR TITLE
Homepage mobile footer title fix

### DIFF
--- a/assets/css/pages/home.css
+++ b/assets/css/pages/home.css
@@ -71,8 +71,17 @@
   justify-content: center;
 }
 
-.ui-community__title {
-  @apply text-6xl mb-4 text-gray-500 dark:text-white-50 font-bold;
+@media screen and (min-width: 601px) {
+  .ui-community__title {
+    @apply text-6xl mb-4 text-gray-500 dark:text-white-50 font-bold;
+  }
+}
+
+
+@media screen and (max-width: 600px) {
+  .ui-community__title {
+    @apply text-2xl text-center mb-4 text-gray-500 dark:text-white-50 font-bold;
+  }
 }
 
 .ui-community__button {


### PR DESCRIPTION
Temporary way to fix the issue https://github.com/devpt-org/devpt-org.github.io/issues/73 regarding the homepage mobile footer title.
Using CSS media screen and min-max width.

Preview:
![image](https://user-images.githubusercontent.com/80425961/125868532-1293c983-8b31-415a-898a-3caf298fdec2.png)